### PR TITLE
Bug fixes

### DIFF
--- a/rsyn/src/rsyn/phy/obj/impl/PhysicalDesign.h
+++ b/rsyn/src/rsyn/phy/obj/impl/PhysicalDesign.h
@@ -388,7 +388,7 @@ inline int PhysicalDesign::getNumMovedCells() const {
 
 		const DBUxy initialPos = phCell.getInitialPosition();
 		const DBUxy currentPos = phCell.getPosition();
-		if (initialPos[X] != currentPos[X] || initialPos[Y] != initialPos[Y])
+		if (initialPos[X] != currentPos[X] || initialPos[Y] != currentPos[Y])
 			count++;
 	} // end for
 	return count;

--- a/rsyn/src/rsyn/util/Bounds.h
+++ b/rsyn/src/rsyn/util/Bounds.h
@@ -231,10 +231,10 @@ public:
 	// Make the lower be +inf and upper be -inf. Useful when computing the
 	// bounding box of a set of points.
 	void degenerate() {
-		(*this)[LOWER][X] = +std::numeric_limits<DBU>::infinity();
-		(*this)[LOWER][Y] = +std::numeric_limits<DBU>::infinity();
-		(*this)[UPPER][X] = -std::numeric_limits<DBU>::infinity();
-		(*this)[UPPER][Y] = -std::numeric_limits<DBU>::infinity();
+		(*this)[LOWER][X] = std::numeric_limits<DBU>::max();
+		(*this)[LOWER][Y] = std::numeric_limits<DBU>::max();
+		(*this)[UPPER][X] = std::numeric_limits<DBU>::min();
+		(*this)[UPPER][Y] = std::numeric_limits<DBU>::min();
 	} // end method
 	
 	// Increases this rectangle so that the point x, y will be inside it.


### PR DESCRIPTION
Fixes an error in the `Bounds` class, in the file `/rsyn/src/rsyn/util/Bounds.h` in function `void degenerate()`, where `std::numeric_limits::infinity()` always returned 0, because it is meaningful only for floating point types, and returns 0 for integer types, such as `DBU` (`std::int64_t`) [src: [cppreference](http://en.cppreference.com/w/cpp/types/numeric_limits/infinity)].

Also fixed a logic error in a comparison in `inline int PhysicalDesign::getNumMovedCells() const` in the file `rsyn-x/rsyn/src/rsyn/phy/obj/impl/PhysicalDesign.h` where the expression always evaluated to `false`.