### PR TITLE
Fix crash populating design with special nets

### DIFF
--- a/rsyn/src/rsyn/io/reader/PopulateRsyn.cpp
+++ b/rsyn/src/rsyn/io/reader/PopulateRsyn.cpp
@@ -340,6 +340,72 @@ void PopulateRsyn::populateRsyn(
 			} // end else
 		} // end for
 	} // end for
+
+    // Creates special nets from DEF
+    for (const DefSpecialNetDscp &net : defDscp.clsSpecialNets) {
+        if (net.clsName == "") {
+            std::cout << "[ERROR] Empty net name.\n";
+            for (unsigned i = 0; i < net.clsConnections.size(); i++) {
+                std::cout << "Connection: " << net.clsConnections[i].clsComponentName << ":" << net.clsConnections[i].clsPinName << "\n";
+            } // end for
+            exit(1);
+        } // end if
+
+        Rsyn::Net rsynNet = top.createNet(net.clsName);
+
+        const string use = net.clsUse;
+        if (use == "ANALOG") {
+            rsynNet.setUse(Rsyn::ANALOG);
+        } else if (use == "CLOCK") {
+            rsynNet.setUse(Rsyn::CLOCK);
+        } else if (use == "GROUND") {
+            rsynNet.setUse(Rsyn::GROUND);
+        } else if (use == "POWER") {
+            rsynNet.setUse(Rsyn::POWER);
+        } else if (use == "RESET") {
+            rsynNet.setUse(Rsyn::RESET);
+        } else if (use == "SCAN") {
+            rsynNet.setUse(Rsyn::SCAN);
+        } else if (use == "SIGNAL") {
+            rsynNet.setUse(Rsyn::SIGNAL);
+        } else if (use == "TIEOFF") {
+            rsynNet.setUse(Rsyn::TIEOFF);
+        } // end if
+
+        for (const DefNetConnection &connection : net.clsConnections) {
+            if (connection.clsComponentName == "PIN") {
+                Rsyn::Port rsynCell =
+                        rsynDesign.findPortByName(connection.clsPinName);
+
+                if (!rsynCell) {
+                    std::cout << "[ERROR] The primary input/ouput port '"
+                              << connection.clsPinName << "' not found.\n";
+                    exit(1);
+                } // end if
+
+                Rsyn::Pin rsynPin = rsynCell.getInnerPin();
+                rsynPin.connect(rsynNet);
+            } else if (connection.clsComponentName == "*") {
+                for (Rsyn::Instance inst: rsynDesign.getTopModule().allInstances()) {
+                    Rsyn::Pin rsynPin = inst.getPinByName(connection.clsPinName);
+                    if (!rsynPin) {
+                        continue;
+                    } // end if
+                    rsynPin.connect(rsynNet);
+                } // end for
+            } else {
+                Rsyn::Cell rsynCell = rsynDesign.findCellByName(connection.clsComponentName);
+                if (!rsynCell) {
+                    std::cout << "[ERROR] Cell '"
+                              << connection.clsComponentName << "' not found.\n";
+                    exit(1);
+                } // end if
+
+                Rsyn::Pin rsynPin = rsynCell.getPinByName(connection.clsPinName);
+                rsynPin.connect(rsynNet);
+            } // end else
+        } // end for
+    } // end for
 } // end method
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
When a Reader is reading a design and both a verilog and a def file are
used for the description of the design, the special nets are only
defined in the def and not in the verilog.

This fix allows the definition of normal nets from the verilog file, and
adds the definitions of the special nets from the def file.