### PR TITLE
Fix all reordering warnings reported by gcc with -Wreorder

### DIFF
--- a/rsyn/src/rsyn/core/obj/data/Arc.h
+++ b/rsyn/src/rsyn/core/obj/data/Arc.h
@@ -17,12 +17,12 @@ namespace Rsyn {
 		
 struct ArcData : ObjectData {
 	ArcType type : 3;
-	Pin from;
-	Pin to;
+	Pin from{nullptr};
+	Pin to{nullptr};
 	
 	union {
 		// Place holder for initialization...
-		void * extra;
+		void * extra{nullptr};
 		
 		// Meaningful only when this is arc belongs to a cell.
 		LibraryArcData * libraryArcData;
@@ -31,12 +31,7 @@ struct ArcData : ObjectData {
 		NetData * netData;
 	}; // end union
 
-	ArcData() : 
-		type(UNKNOWN_ARC_TYPE),
-		extra(nullptr),
-		from(nullptr), 
-		to(nullptr) {
-	} // end constructor
+  ArcData() :type(UNKNOWN_ARC_TYPE) {}
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/core/obj/data/Design.h
+++ b/rsyn/src/rsyn/core/obj/data/Design.h
@@ -33,8 +33,8 @@ struct DesignData {
 	std::vector<std::string> instanceNames;
 	std::vector<std::string> netNames;
 	
-	int anonymousInstanceId;
-	int anonymousNetId;
+	int anonymousInstanceId{0};
+	int anonymousNetId{0};
 	
 	std::unordered_map<std::string, Instance> instanceMapping;
 	std::unordered_map<std::string, Net> netMapping;
@@ -43,30 +43,20 @@ struct DesignData {
 	std::array<LibraryCell, NUM_SIGNAL_DIRECTIONS> portLibraryCells;
 	std::set<Cell> ports[NUM_SIGNAL_DIRECTIONS];
 	
-	std::array<int, NUM_INSTANCE_TYPES> instanceCount;
+	std::array<int, NUM_INSTANCE_TYPES> instanceCount{0, 0, 0};
 	
 	std::vector<Pin> structuralStartpoints;
 	std::vector<Pin> structuralEndpoints;	
 	std::vector<Net> netsInTopologicalOrder;
 	
-	bool dirty;	
-	bool initialized;
+	bool dirty{false};
+	bool initialized{false};
 	
 	// Used for some netlist traversing (e.g. update topological ordering)...
-	int sign;	
+	int sign{0};
 	
 	// Observers
 	std::array<std::list<DesignObserver *>, NUM_DESIGN_EVENTS> observers;
-	
-	// Constructor
-	DesignData() :
-		initialized(false),
-		dirty(false),
-		anonymousInstanceId(0),
-		anonymousNetId(0),
-		instanceCount({0, 0, 0}),
-		sign(0) {
-	} // end constructor
 }; // end class
 
 } // end namespace

--- a/rsyn/src/rsyn/core/obj/data/Instance.h
+++ b/rsyn/src/rsyn/core/obj/data/Instance.h
@@ -23,25 +23,25 @@ struct InstanceTagData {
 // -----------------------------------------------------------------------------
 
 struct InstanceData : ObjectData {
-	InstanceType type;
+	InstanceType type{UNKNOWN_INSTANCE_TYPE};
 		
 	std::vector<Pin> pins;
 	std::vector<Arc> arcs;
 	
 	// Design (Cached)
 	// @todo Remove.
-	Design design;
+	Design design{nullptr};
 	
 	// The module where this instance is instantiated. If only null for the top
 	// module.
-	Module parent;
+	Module parent{nullptr};
 	
 	// Local index inside it's parent module.
-	Index mid;
+	Index mid{std::numeric_limits<Index>::max()};
 
 	// Extra data for different types of instances.
 	union {
-		void * extra;
+		void * extra{nullptr};
 		
 		ModuleData * moduleData;
 		PinData * outerPin;
@@ -52,21 +52,9 @@ struct InstanceData : ObjectData {
 	InstanceTagData tag;
 
 	// Physical information.
-	Bounds clsBounds;
-	PhysicalOrientation clsOrientation;
-	DBUxy clsPortPos; // only for port to define position. (@todo remove, use bounds instead).
-
-	// Constructor
-	InstanceData() : 
-		design(nullptr),
-		type(UNKNOWN_INSTANCE_TYPE),
-		parent(nullptr),
-		extra(nullptr),
-		mid(-1),
-		clsBounds(0, 0, 0, 0),
-		clsOrientation(ORIENTATION_N), // @todo set to R0 by default
-		clsPortPos(0, 0) {
-	} // end constructor
+	Bounds clsBounds{0, 0, 0, 0};
+	PhysicalOrientation clsOrientation{ORIENTATION_N}; // @todo set to R0 by default
+	DBUxy clsPortPos{0, 0}; // only for port to define position. (@todo remove, use bounds instead).
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/core/obj/data/LibraryCell.h
+++ b/rsyn/src/rsyn/core/obj/data/LibraryCell.h
@@ -30,27 +30,19 @@ struct LibraryCellTagData {
 // -----------------------------------------------------------------------------
 
 struct LibraryCellData : ObjectData {
-	Design design;
+	Design design{nullptr};
 	std::string name;
 	std::vector<LibraryPin> pins;
 	std::vector<LibraryArc> arcs;
-	DBUxy size;
+	DBUxy size{0, 0};
 
 	// User flags.
 	LibraryCellTagData tag;
 
 	// TODO: use array
-	int numInputPins;
-	int numOutputPins;
-	int numInOutPins;
-
-	LibraryCellData() : 
-		design(nullptr),
-		numInputPins(0),
-		numOutputPins(0), 
-		numInOutPins(0),
-		size(0, 0) {
-	} // constructor
+	int numInputPins{0};
+	int numOutputPins{0};
+	int numInOutPins{0};
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/core/obj/data/Net.h
+++ b/rsyn/src/rsyn/core/obj/data/Net.h
@@ -28,7 +28,7 @@ struct NetTagData {
 
 struct NetData : ObjectData {
 	// Index in parent module.
-	Index mid;
+	Index mid{std::numeric_limits<Index>::max()};
 
 	// User tags.
 	NetTagData tag;
@@ -37,27 +37,18 @@ struct NetData : ObjectData {
 	std::vector<Pin> pins;
 	
 	// Driver. If multiple-drivers, store one of them without any assumptions.
-	Pin driver;
+	Pin driver{nullptr};
 	
 	// Parent
-	Module parent;
+	Module parent{nullptr};
 	
-	std::array<int, NUM_SIGNAL_DIRECTIONS> numPinsOfType;
+	std::array<int, NUM_SIGNAL_DIRECTIONS> numPinsOfType{0, 0, 0, 0};
 	
 	// Helper used for netlist traversals.
-	int sign;
+	int sign{-1};
 	
 	// Mateus @ 20190204: Adding net use;
-	Use netUse;
-	
-	NetData() : 
-		mid(-1),
-		sign(-1),
-		driver(nullptr), 
-		numPinsOfType({0, 0, 0, 0}),
-		parent(nullptr),
-		netUse(UNKNOWN_USE) {
-	} // end constructor	
+	Use netUse{UNKNOWN_USE};
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/io/legacy/PlacerInternals.h
+++ b/rsyn/src/rsyn/io/legacy/PlacerInternals.h
@@ -77,27 +77,24 @@ struct Design {
 	};
 
 	struct Track {
-		std::string direction; //X or Y
-		int doStart;
-		int doCount;
-		int doStep;
-		int numLayers;
+		std::string direction{"NULL"}; //X or Y
+		int doStart{-1};
+		int doCount{-1};
+		int doStep{-1};
+		int numLayers{-1};
 		std::vector<std::string> layers;
-		Track () : direction("NULL"), doStart(-1), doCount(-1), doStep(-1),
-		numLayers(-1) {}
 	};
 	
 	struct GCellGrid {
-		std::string master; // direction X or Y
-		int doStart;
-		int doCount;
-		int doStep;
-		GCellGrid () : master("null"), doStart(-1), doCount(-1), doStep(-1) {}
+		std::string master{"null"}; // direction X or Y
+		int doStart{-1};
+		int doCount{-1};
+		int doStep{-1};
 	};
 	
 	std::string name;
-	double distanceUnit;
-	double defVersion;
+	double distanceUnit{1.0};
+	double defVersion{-1.0};
 	
 	std::vector<Component> components;
 	std::vector<Pin> ports;
@@ -111,11 +108,6 @@ struct Design {
 	std::vector<GCellGrid> gCellGrids;
 	
 	DieArea dieArea;
-	
-	Design() {
-		distanceUnit = 1;
-		defVersion = -1;
-	}
 }; // end struct
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,25 +116,21 @@ struct Design {
 
 struct Library {
 	struct Site {
-		std::string name;
-		std::string classSite;
-		bool hasClass;
-		double w;
-		double h;
-		
-		Site() :name("null"), classSite("null"), hasClass(false), w(0), h(0) {}
+		std::string name{"null"};
+		std::string classSite{"null"};
+		bool hasClass{false};
+		double w{0};
+		double h{0};
 	};
 	
 	struct Pin {
 		std::string name;
 		std::string direction;
-		std::string metalLayer;
+		std::string metalLayer{"null"};
 		Bounds bound;
 		std::vector<Bounds> routerPins;
-		double dx;
-		double dy;
-		
-		Pin() : dx(0), dy(0), metalLayer("null") {}
+		double dx{0.0};
+		double dy{0.0};
 	};
 	
 	struct Obstruction {
@@ -154,22 +142,19 @@ struct Library {
 		std::string name;
 		std::string type;
 		std::string site;
-		double w;
-		double h;
+		double w{0.0};
+		double h{0.0};
 		std::vector<Pin> pins;
 		std::vector<Obstruction> obs;
-		Macro () : w(0), h(0) {}
 	}; // end struct
 	
 	struct Layer { // for metals, vias and contacts
-		std::string name;
-		std::string type;
-		std::string direction;
-		double pitch;
-		double width;
-		double spacing;
-		Layer () : name("null"), type("null"), direction("null"), 
-		pitch(-1), width(-1), spacing(-1) {}
+		std::string name{"null"};
+		std::string type{"null"};
+		std::string direction{"null"};
+		double pitch{-1.0};
+		double width{-1.0};
+		double spacing{-1.0};
 	};
 	
 	struct Spacing {
@@ -179,13 +164,11 @@ struct Library {
 	};
 		
 	std::string name;
-	double distanceUnit;
+	double distanceUnit{1.0};
 	std::vector<Macro> macros;
 	std::vector<Site> sites;
 	std::vector<Layer> layers;
 	std::vector<Spacing> metalSpaces;
-	
-	Library() : distanceUnit(1) {}	
 }; // end struct
 
 
@@ -211,38 +194,35 @@ struct DefStruct1 {
 	
 	struct DefRow {
 		std::string rowName;
-		std::string rowType;
-		int origX;
-		int origY;
-		int orient;
-		int doCount;
-		int doIncrement;
-		int xStep;
-		int yStep;
-		DefRow () : rowType("core"), origX(0), origY(0), orient(0), doCount(0), doIncrement(0), xStep(0), yStep(0) {}
-		// orient {0, 1, 2, 3, 4, 5, 6, 7} = {N, W, S, E, FN, FW, FS, FE} source: defapi.pdf version 5.8 
+		std::string rowType{"core"};
+		int origX{0};
+		int origY{0};
+		int orient{0};
+		int doCount{0};
+		int doIncrement{0};
+		int xStep{0};
+		int yStep{0};
+		// orient {0, 1, 2, 3, 4, 5, 6, 7} = {N, W, S, E, FN, FW, FS, FE} source: defapi.pdf version 5.8
 	};
 
 	struct DefPortLayer {
-		std::string layerName;
-		int spacing;
-		int designRuleWidth;
+		std::string layerName{"NULL"};
+		int spacing{0};
+		int designRuleWidth{0};
 		Bounds bounds;
-		DefPortLayer() : spacing(0), designRuleWidth(0), layerName("NULL") {}
 	};
 
 	struct DefPort {
 		std::string portName;
 		std::string netName;
-		int special; // 0 is ignored; 1 writes a SPECIAL statement
-		std::string direction; // {NULL, FEEDTHRU, INPUT, INOUT, OUTPUT}
-		std::string use; // {NULL, ANALOG, CLOCK, GROUND, POWER, RESET, SCAN, SIGNAL, TIEOFF}
-		std::string status; // {NULL, COVER, FIXED, PLACED} 
-		int statusX; // placement location; 0 ignore
-		int statusY; // placement location; 0 ignore
-		int orient;  // orient {-1, 0, 1, 2, 3, 4, 5, 6, 7} = {IGNORE, N, W, S, E, FN, FW, FS, FE} source: defapi.pdf version 5.8 
+		int special{0}; // 0 is ignored; 1 writes a SPECIAL statement
+		std::string direction{"NULL"}; // {NULL, FEEDTHRU, INPUT, INOUT, OUTPUT}
+		std::string use{"NULL"}; // {NULL, ANALOG, CLOCK, GROUND, POWER, RESET, SCAN, SIGNAL, TIEOFF}
+		std::string status{"NULL"}; // {NULL, COVER, FIXED, PLACED}
+		int statusX{0}; // placement location; 0 ignore
+		int statusY{0}; // placement location; 0 ignore
+		int orient{-1};  // orient {-1, 0, 1, 2, 3, 4, 5, 6, 7} = {IGNORE, N, W, S, E, FN, FW, FS, FE} source: defapi.pdf version 5.8
 		DefPortLayer clsDefPortLayer;
-		DefPort () : direction("NULL"), orient(-1), special(0), status("NULL"), use("NULL") {}
 	};
 
 	std::vector<DefMacro> clsDefMacros;

--- a/rsyn/src/rsyn/io/parser/liberty/LibertyControlParser.h
+++ b/rsyn/src/rsyn/io/parser/liberty/LibertyControlParser.h
@@ -54,17 +54,11 @@ private:
 	}; // end enum
 
 	struct LookUpTableTemplate {
-		LutVariableType var1;
-		LutVariableType var2;
-		
-		int loadIndex;
-		int slewIndex;
-		
-		LookUpTableTemplate() :
-			loadIndex(-1),
-			slewIndex(-1),
-			var1(LUT_VARIABLE_INVALID),
-			var2(LUT_VARIABLE_INVALID){}
+		LutVariableType var1{LUT_VARIABLE_INVALID};
+		LutVariableType var2{LUT_VARIABLE_INVALID};
+
+		int loadIndex{-1};
+		int slewIndex{-1};
 	}; // end struct
 	
 	LutVariableType getLutVariableTypeFromString(const std::string &str) {

--- a/rsyn/src/rsyn/io/parser/script/ScriptCommand.h
+++ b/rsyn/src/rsyn/io/parser/script/ScriptCommand.h
@@ -207,12 +207,10 @@ friend class ParsedCommand;
 friend class Command;
 private:
 	Rsyn::Json clsJson;
-	ParsedParamType clsType;
-	int clsPosition;
-	std::string clsName;	
+	ParsedParamType clsType{PARSED_PARAM_TYPE_NULL};
+	int clsPosition{-1};
+	std::string clsName;
 
-	ParsedParam() : clsPosition(-1), clsType(PARSED_PARAM_TYPE_NULL) {}
-	
 	const Rsyn::Json &
 	getValue() const {
 		return clsJson;

--- a/rsyn/src/rsyn/model/scenario/Scenario.h
+++ b/rsyn/src/rsyn/model/scenario/Scenario.h
@@ -69,35 +69,31 @@ public:
 	class TimingLibraryPin {
 	friend class Scenario;
 	private:
-		int index;
+		int index{-1};
 
 		// Input capacitance associates to this pin.
-		Number capacitance;
+		Number capacitance{0};
 		
 		//Output max capacitance
-		Number maxCapacitance;
+		Number maxCapacitance{0};
 		
 		//Input max transition
-		Number maxTransition;
+		Number maxTransition{0};
 
 		// Indicates if this pin is the clock pin of a register.
-		bool clocked;
+		bool clocked{false};
 
 		// For non-sequential pins, always = -1
 		// For sequential pins,
 		//     if clocked = true; indicates the index of the data pin;
 		//     if clocked = false; indicates the index of the clock pin;
-		int control;
+		int control{-1};
 
 		// Look-up tables.
 		ISPD13::LibParserLUT setup[NUM_EDGE_TYPES];
 		ISPD13::LibParserLUT hold[NUM_EDGE_TYPES];	
 
 	public:
-		
-		TimingLibraryPin() : index(-1), control(-1), clocked(false), capacitance(0),
-		maxCapacitance(0), maxTransition(0) {}
-
 		const ISPD13::LibParserLUT &getSetupLut(const EdgeType &edge) const { return setup[edge]; }
 		const ISPD13::LibParserLUT &getHoldLut(const EdgeType &edge) const { return hold[edge]; }		
 		

--- a/rsyn/src/rsyn/model/timing/SandboxTimer.h
+++ b/rsyn/src/rsyn/model/timing/SandboxTimer.h
@@ -948,26 +948,16 @@ public:
 	class PathHop {
 	friend class SandboxTimer;
 	private:
-		Rsyn::SandboxArc rsynArcFromThisPin;
-		Rsyn::SandboxArc rsynArcToThisPin;
-		Number arrival;
-		Number required;
-		Number delay;
-		Rsyn::SandboxPin pin;
-		Rsyn::SandboxPin previousPin;
-		Rsyn::SandboxPin nextPin;
+		Rsyn::SandboxArc rsynArcFromThisPin{nullptr};
+		Rsyn::SandboxArc rsynArcToThisPin{nullptr};
+		Number arrival{std::numeric_limits<Number>::quiet_NaN()};
+		Number required{std::numeric_limits<Number>::quiet_NaN()};
+		Number delay{std::numeric_limits<Number>::quiet_NaN()};
+		Rsyn::SandboxPin pin{nullptr};
+		Rsyn::SandboxPin previousPin{nullptr};
+		Rsyn::SandboxPin nextPin{nullptr};
 		TimingTransition transition;
 		TimingMode mode; // stored for commodity, used to compute slack
-
-		PathHop() :
-		arrival(std::numeric_limits<Number>::quiet_NaN()),
-		required(std::numeric_limits<Number>::quiet_NaN()),
-		delay(std::numeric_limits<Number>::quiet_NaN()),
-		pin(nullptr),
-		previousPin(nullptr),
-		nextPin(nullptr),
-		rsynArcFromThisPin(nullptr),
-		rsynArcToThisPin(nullptr){}
 
 	public:
 
@@ -1011,12 +1001,12 @@ private:
 
 	// Helper structure used to generate critical paths.
 	struct Reference {
-		Rsyn::SandboxPin propPin;
-		TimingArc * propArcPointerFromThisPin;
-		Rsyn::SandboxArc propRsynArcFromThisPin;
+		Rsyn::SandboxPin propPin{nullptr};
+		TimingArc * propArcPointerFromThisPin{nullptr};
+		Rsyn::SandboxArc propRsynArcFromThisPin{nullptr};
 		TimingTransition propTransition;
-		Number propRequired;
-		int propParentPartialPath;
+		Number propRequired{std::numeric_limits<Number>::quiet_NaN()};
+		int propParentPartialPath{-1};
 		TimingTransition propTransitionAtParent;
 
 		// This is not the actual slack in the current path. This is computed
@@ -1024,17 +1014,10 @@ private:
 		// at this pin) and the worst arrival time.
 		// The actual slack in this path will be computed later during the
 		// backtracking.
-		Number propSlack;
+		Number propSlack{std::numeric_limits<Number>::quiet_NaN()};
 
 		// Constructor.
-		Reference() :
-			propPin(nullptr),
-			propArcPointerFromThisPin(nullptr),
-			propRsynArcFromThisPin(nullptr),
-			propRequired(std::numeric_limits<Number>::quiet_NaN()),
-			propSlack(std::numeric_limits<Number>::quiet_NaN()),
-			propParentPartialPath(-1)
-		{}
+		Reference() = default;
 
 		Reference(Rsyn::SandboxPin pin,
 				TimingArc * arc,
@@ -1048,11 +1031,11 @@ private:
 				propPin(pin),
 				propArcPointerFromThisPin(arc),
 				propRsynArcFromThisPin(rsynArc),
-				propRequired(required),
-				propSlack(slack),
-				propTransition(transition),
+        propTransition(transition),
+        propRequired(required),
 				propParentPartialPath(parent),
-				propTransitionAtParent(transitionAtParent) {}
+        propTransitionAtParent(transitionAtParent),
+				propSlack(slack) {}
 
 		bool operator>(const Reference &rhs) const {
 			return (propSlack > rhs.propSlack);

--- a/rsyn/src/rsyn/model/timing/Timer.h
+++ b/rsyn/src/rsyn/model/timing/Timer.h
@@ -1678,32 +1678,18 @@ public:
 	class PathHop {
 	friend class Timer;
 	private:
-		Rsyn::Arc rsynArcFromThisPin;
-		Rsyn::Arc rsynArcToThisPin;
-		Number arrival;
-		Number required;
-		Number delay;
-		Rsyn::Pin pin;
-		Rsyn::Pin previousPin;
-		Rsyn::Pin nextPin;
-		TimingTransition transition;
-		TimingTransition previousTransition;
-		TimingTransition nextTransition;
+		Rsyn::Arc rsynArcFromThisPin{nullptr};
+		Rsyn::Arc rsynArcToThisPin{nullptr};
+		Number arrival{std::numeric_limits<Number>::quiet_NaN()};
+		Number required{std::numeric_limits<Number>::quiet_NaN()};
+		Number delay{std::numeric_limits<Number>::quiet_NaN()};
+		Rsyn::Pin pin{nullptr};
+		Rsyn::Pin previousPin{nullptr};
+		Rsyn::Pin nextPin{nullptr};
+		TimingTransition transition{Rsyn::TIMING_TRANSITION_INVALID};
+		TimingTransition previousTransition{Rsyn::TIMING_TRANSITION_INVALID};
+		TimingTransition nextTransition{Rsyn::TIMING_TRANSITION_INVALID};
 		TimingMode mode; // stored for commodity, used to compute slack
-		
-		PathHop() :
-			arrival(std::numeric_limits<Number>::quiet_NaN()),
-			required(std::numeric_limits<Number>::quiet_NaN()),
-			delay(std::numeric_limits<Number>::quiet_NaN()),
-			pin(nullptr),
-			previousPin(nullptr),
-			nextPin(nullptr),
-			rsynArcFromThisPin(nullptr),
-			rsynArcToThisPin(nullptr),
-			transition(Rsyn::TIMING_TRANSITION_INVALID),
-			previousTransition(Rsyn::TIMING_TRANSITION_INVALID),
-			nextTransition(Rsyn::TIMING_TRANSITION_INVALID)
-		{}
 				
 	public:
 		
@@ -1750,12 +1736,12 @@ private:
 
 	// Helper structure used to generate critical paths.
 	struct Reference {
-		Rsyn::Pin propPin;
-		TimingArc * propArcPointerFromThisPin;
-		Rsyn::Arc propRsynArcFromThisPin;
-		TimingTransition propTransition;
-		Number propRequired;
-		int propParentPartialPath;
+		Rsyn::Pin propPin{nullptr};
+		TimingArc * propArcPointerFromThisPin{nullptr};
+		Rsyn::Arc propRsynArcFromThisPin{nullptr};
+		TimingTransition propTransition{Rsyn::TIMING_TRANSITION_INVALID};
+		Number propRequired{std::numeric_limits<Number>::quiet_NaN()};
+		int propParentPartialPath{-1};
 		TimingTransition propTransitionAtParent;
 		
 		// This is not the actual slack in the current path. This is computed
@@ -1763,18 +1749,10 @@ private:
 		// at this pin) and the worst arrival time.
 		// The actual slack in this path will be computed later during the 
 		// backtracking.
-		Number propSlack; 
+		Number propSlack{std::numeric_limits<Number>::quiet_NaN()};
 		
 		// Constructor.
-		Reference() :
-			propPin(nullptr),
-			propArcPointerFromThisPin(nullptr),
-			propRsynArcFromThisPin(nullptr),
-			propRequired(std::numeric_limits<Number>::quiet_NaN()),
-			propSlack(std::numeric_limits<Number>::quiet_NaN()),
-			propParentPartialPath(-1),
-			propTransition(Rsyn::TIMING_TRANSITION_INVALID)
-		{}
+		Reference() = default;
 		
 		Reference(Rsyn::Pin pin, 
 				TimingArc * arc,
@@ -1788,11 +1766,11 @@ private:
 				propPin(pin),
 				propArcPointerFromThisPin(arc),
 				propRsynArcFromThisPin(rsynArc),
-				propRequired(required),
-				propSlack(slack),
-				propTransition(transition),
-				propParentPartialPath(parent),
-				propTransitionAtParent(transitionAtParent) {}
+        propTransition(transition),
+        propRequired(required),
+        propParentPartialPath(parent),
+        propTransitionAtParent(transitionAtParent),
+        propSlack(slack) {}
 					
 		bool operator>(const Reference &rhs) const {
 			return (propSlack > rhs.propSlack);

--- a/rsyn/src/rsyn/model/timing/TimingLibraryPin.h
+++ b/rsyn/src/rsyn/model/timing/TimingLibraryPin.h
@@ -21,18 +21,16 @@
 namespace Rsyn {
 	
 struct TimingLibraryPin {
-	int index;
+	int index{-1};
 
 	// Indicates if this pin is the clock pin of a register.
-	bool clocked;
+	bool clocked{false};
 	
 	// For non-sequential pins, always = -1
 	// For sequential pins,
 	//     if clocked = true; indicates the index of the data pin;
 	//     if clocked = false; indicates the index of the clock pin;
-	int control;
-	
-	TimingLibraryPin() : index(-1), control(-1), clocked(false) {}
+	int control{-1};
 }; // end class
 
 } // end namespace

--- a/rsyn/src/rsyn/phy/obj/data/PhysicalDesign.h
+++ b/rsyn/src/rsyn/phy/obj/data/PhysicalDesign.h
@@ -22,8 +22,8 @@ namespace Rsyn {
 class PhysicalDesignData : public PhysicalObject {
 	friend class PhysicalDesign;
 public:
-	Rsyn::Design clsDesign;
-	Rsyn::Module clsModule;
+	Rsyn::Design clsDesign{nullptr};
+	Rsyn::Module clsModule{nullptr};
 	Rsyn::LayerViaManagerData clsLayerViaManager;
 
 	std::list<std::function<void(Rsyn::Instance cell) >> callbackAddCreatePhysicalCell;
@@ -74,7 +74,7 @@ public:
 	bool clsEnableMergeRectangles : 1;
 	bool clsEnableNetPinBoundaries : 1;
 
-	Rsyn::Net clsClkNet;
+	Rsyn::Net clsClkNet{nullptr};
 	
 	// Physical design mode 
 	PhysicalDesignMode clsMode = PhysicalDesignMode::ALL;
@@ -85,8 +85,7 @@ public:
 
 	std::array<std::list<PhysicalDesignObserver *>, NUM_PHYSICAL_EVENTS> clsPhysicalObservers;
 
-	PhysicalDesignData() : clsClkNet(nullptr), clsDesign(nullptr), clsModule(nullptr) {
-
+	PhysicalDesignData() {
 		clsLoadDesign = false;
 		clsEnablePhysicalPins = false;
 		clsEnableMergeRectangles = false;
@@ -95,7 +94,7 @@ public:
 			clsDBUs[index] = 0;
 		} // end for 
 		for (int index = 0; index < NUM_PHYSICAL_TYPES; index++) {
-			clsTotalAreas[index] = 0.0;
+			clsTotalAreas[index] = 0;
 			clsNumElements[index] = 0;
 		} // end for  
 		for (int index = 0; index < NUM_PHY_LAYER; index++) {

--- a/rsyn/src/rsyn/qt/graphics/infra/GraphicsView.cpp
+++ b/rsyn/src/rsyn/qt/graphics/infra/GraphicsView.cpp
@@ -47,14 +47,7 @@ static const bool DebugRendering = false;
 
 // -----------------------------------------------------------------------------
 
-GraphicsView::GraphicsView(QWidget *parent) :
-		QGraphicsView(parent),
-		zoomScaling(1),
-		sceneToViewportScalingFactor(0),
-		rowHeight(0),
-		initialized(false)
-{
-
+GraphicsView::GraphicsView(QWidget *parent) : QGraphicsView(parent) {
     setRenderHint(QPainter::Antialiasing, false);
     setDragMode(QGraphicsView::RubberBandDrag);
     setOptimizationFlags(

--- a/rsyn/src/rsyn/qt/graphics/infra/GraphicsView.h
+++ b/rsyn/src/rsyn/qt/graphics/infra/GraphicsView.h
@@ -114,11 +114,11 @@ private:
 
 	//! @brief Indicates whether or not this graphics view was already
 	//! initialized.
-	bool initialized = false;
+	bool initialized{false};
 
 	// Current zoom.
-	qreal zoomScaling;
-	qreal initialZoomScaling = 1;
+	qreal zoomScaling{1};
+	qreal initialZoomScaling{1};
 
 	// The bounds of the scene (user space) adjusted to the aspect ratio of the
 	// viewport. When zoom = 1, it means the adjustedSceneRect fits exactly
@@ -126,13 +126,13 @@ private:
 	QRectF adjustedSceneRect;
 
 	// The scaling required to map user coordinates to viewport coordinates.
-	qreal sceneToViewportScalingFactor;
-	qreal rowHeight;
+	qreal sceneToViewportScalingFactor{0};
+	qreal rowHeight{0};
 
 	QTransform invertedTransform;
 
 	Rsyn::PhysicalDesign physicalDesign;
-	Rsyn::Graphics *rsynGraphics = nullptr;
+	Rsyn::Graphics *rsynGraphics{nullptr};
 
 }; // end method
 

--- a/rsyn/src/rsyn/qt/window/MainWindow.cpp
+++ b/rsyn/src/rsyn/qt/window/MainWindow.cpp
@@ -78,11 +78,7 @@ static const int MAX_COMMAND_HISTORY_LENGTH = 100;
 
 // -----------------------------------------------------------------------------
 
-MainWindow::MainWindow(QWidget *parent) :
-	QMainWindow(parent),
-		view(nullptr),
-		scene(nullptr)
-{
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 	setupUi(this);
 	statusBar()->show();
 

--- a/rsyn/src/rsyn/sandbox/obj/data/Arc.h
+++ b/rsyn/src/rsyn/sandbox/obj/data/Arc.h
@@ -17,12 +17,12 @@ namespace Rsyn {
 		
 struct SandboxArcData : ObjectData {
 	ArcType type : 2;
-	SandboxPin from;
-	SandboxPin to;
+	SandboxPin from{nullptr};
+	SandboxPin to{nullptr};
 	
 	union {
 		// Place holder for initialization...
-		void * extra;
+		void * extra{nullptr};
 		
 		// Meaningful only when this is arc belongs to a cell.
 		LibraryArcData * libraryArcData;
@@ -31,11 +31,7 @@ struct SandboxArcData : ObjectData {
 		SandboxNetData * netData;
 	}; // end union
 
-	SandboxArcData() :
-		type(UNKNOWN_ARC_TYPE),
-		extra(nullptr),
-		from(nullptr), 
-		to(nullptr) {
+	SandboxArcData() : type(UNKNOWN_ARC_TYPE) {
 	} // end constructor
 }; // end struct
 

--- a/rsyn/src/rsyn/sandbox/obj/data/Net.h
+++ b/rsyn/src/rsyn/sandbox/obj/data/Net.h
@@ -28,19 +28,13 @@ struct SandboxNetData : SandboxObjectData {
 	std::vector<SandboxPin> pins;
 	
 	// Driver. If multiple-drivers, store one of them without any assumptions.
-	SandboxPin driver;
+	SandboxPin driver{nullptr};
 
 	// Cache number of pins per direction.
-	std::array<int, NUM_SIGNAL_DIRECTIONS> numPinsOfType;
+	std::array<int, NUM_SIGNAL_DIRECTIONS> numPinsOfType{0, 0, 0, 0};
 	
 	// Ussed in some netlist traversals.
-	int sign;
-
-	SandboxNetData() :
-		sign(-1),
-		driver(nullptr), 
-		numPinsOfType({0, 0, 0, 0}) {
-	} // end constructor	
+	int sign{-1};
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/sandbox/obj/data/Sandbox.h
+++ b/rsyn/src/rsyn/sandbox/obj/data/Sandbox.h
@@ -27,14 +27,14 @@ struct SandboxData {
 	std::vector<std::string> instanceNames;
 	std::vector<std::string> netNames;
 
-	int anonymousInstanceId;
-	int anonymousNetId;
+	int anonymousInstanceId{0};
+	int anonymousNetId{0};
 
-	bool dirty;
-	bool initialized;
+	bool dirty{false};
+	bool initialized{false};
 
 	// Used for some netlist traversing (e.g. update topological ordering)...
-	int sign;
+	int sign{0};
 	
 	std::unordered_map<std::string, SandboxInstance> instanceNameMapping;
 	std::unordered_map<std::string, SandboxNet> netMapping;
@@ -43,15 +43,6 @@ struct SandboxData {
 
 	List<SandboxPort, RSYN_SANDBOX_LIST_CHUNCK_SIZE> ports;
 	std::set<SandboxPort> portsByDirection[Rsyn::NUM_SIGNAL_DIRECTIONS];
-
-	SandboxData() :
-		initialized(false),
-		dirty(false),
-		anonymousInstanceId(0),
-		anonymousNetId(0),
-		sign(0) {
-	} // end constructor
-
 }; // end struct
 
 } // end namespace

--- a/rsyn/src/rsyn/util/geometry/Rect.h
+++ b/rsyn/src/rsyn/util/geometry/Rect.h
@@ -30,10 +30,9 @@ class Polygon;
 
 class Rect {
 public:
-
-	Rect() : clsLower(0, 0), clsUpper(0, 0) {}
-	Rect(const DBU x, const DBU y, const DBU w, const DBU h) : clsLower(x, y), clsUpper(x + w, y + h) {}
-	Rect(const Bounds &bounds) : clsLower(bounds.getLower()), clsUpper(bounds.getUpper()) {}
+  Rect() = default;
+	Rect(const DBU x, const DBU y, const DBU w, const DBU h) : clsUpper(x + w, y + h), clsLower(x, y) {}
+	Rect(const Bounds &bounds) : clsUpper(bounds.getUpper()), clsLower(bounds.getLower()) {}
 
 	DBU getX() const {return clsLower.getX();}
 	DBU getY() const {return clsLower.getY();}
@@ -115,8 +114,8 @@ public:
 
 private:
 
-	Point clsUpper;
-	Point clsLower;
+	Point clsUpper{0, 0};
+	Point clsLower{0, 0};
 
 }; // end class
 

--- a/x/src/x/jezz/Jezz.h
+++ b/x/src/x/jezz/Jezz.h
@@ -716,28 +716,21 @@ public:
 public:
 
 	struct WhitespaceDescriptor {
-		JezzNode *node; // whitespace node
-		DBU x; // minimum x of the whitespace
-		DBU y; // minumum y of the whitespace
-		DBU w; // whitespace width
+		JezzNode *node{nullptr}; // whitespace node
+		DBU x{std::numeric_limits<DBU>::quiet_NaN()}; // minimum x of the whitespace
+		DBU y{std::numeric_limits<DBU>::quiet_NaN()}; // minumum y of the whitespace
+		DBU w{std::numeric_limits<DBU>::quiet_NaN()}; // whitespace width
 
 		// Position where the cell should be inserted inside whitespace 
 		// accounting for snapping noise. Note that the whitespace can be much 
 		// larger than the node.
-		DBU x_insertion; // x_insertion >= x
+		DBU x_insertion{std::numeric_limits<DBU>::quiet_NaN()}; // x_insertion >= x
 		
 		// Distance from target position (computed based on the insertion 
 		// position).
-		DBU distance; 
+		DBU distance{std::numeric_limits<DBU>::quiet_NaN()};
 		
-		WhitespaceDescriptor() {
-			node = nullptr;
-			x = std::numeric_limits<DBU>::quiet_NaN();
-			y = std::numeric_limits<DBU>::quiet_NaN();
-			x_insertion = std::numeric_limits<DBU>::quiet_NaN();
-			w = std::numeric_limits<DBU>::quiet_NaN();
-			distance = std::numeric_limits<DBU>::quiet_NaN();
-		} // end constructor
+		WhitespaceDescriptor() = default;
 
 		WhitespaceDescriptor(
 				JezzNode *node,
@@ -746,7 +739,7 @@ public:
 				const DBU x_insertion,
 				const DBU w, 
 				const DBU distance) :
-			node(node), x(x), y(y), x_insertion(x_insertion), w(w), distance(distance) {
+			node(node), x(x), y(y), w(w), x_insertion(x_insertion), distance(distance) {
 		} // end constructor
 
 		bool operator<(const WhitespaceDescriptor &rhs) const {

--- a/x/src/x/opto/ufrgs/qpdp/IncrementalTimingDrivenQP.h
+++ b/x/src/x/opto/ufrgs/qpdp/IncrementalTimingDrivenQP.h
@@ -33,23 +33,23 @@ class LibraryCharacterizer;
 
 class IncrementalTimingDrivenQP : public Rsyn::Process {
 private:
-	Rsyn::Session session;
-	Infrastructure *infra;
-	Rsyn::Design design;
+	Rsyn::Session session{nullptr};
+	Infrastructure *infra{nullptr};
+	Rsyn::Design design{nullptr};
 	Rsyn::Module module;
 	Rsyn::PhysicalDesign phDesign;
-	Rsyn::Timer *timer;
+	Rsyn::Timer *timer{nullptr};
 	Rsyn::RoutingEstimator *routingEstimator;
-	const Rsyn::LibraryCharacterizer *libc;
+	const Rsyn::LibraryCharacterizer *libc{nullptr};
 	
-	bool debugMode;
-	bool enableRC;
+	bool debugMode{false};
+	bool enableRC{false};
 	
-	double minimumResistance;
+	double minimumResistance{0.01};
 	    
 	/* Numberic values for tunning the algorithms */
 protected:
-	Number alpha;
+	Number alpha{0};
 	Number beta;
 public:
 	const Number getAlpha() const { return alpha; }
@@ -58,7 +58,7 @@ public:
 	void setBeta( const Number beta ) { this->beta = beta; }
 
 protected:
-	int maxNumPaths;
+	int maxNumPaths{5000};
 public:
 	const int getMaxNumPaths() const { return maxNumPaths; }
 	void setMaxNumPaths( const int maxNumPaths ) { this->maxNumPaths = maxNumPaths; }
@@ -68,8 +68,8 @@ private:
 	std::set<Rsyn::Cell> movable;
 	std::vector< std::pair< double, Rsyn::Net > > criticalNets;
 	
-	LegalizationMethod legMode;
-	bool roolbackOnMaxDisplacementViolation;
+	LegalizationMethod legMode{LegalizationMethod::LEG_NEAREST_WHITESPACE};
+	bool roolbackOnMaxDisplacementViolation{true};
 
 //	std::map<Rsyn::Cell, int> mapCellToIndex;
 	Rsyn::Attribute<Rsyn::Instance, int> mapCellToIndex;
@@ -145,15 +145,6 @@ private:
 	
 	void doNoHarm();
 public:
-	
-	IncrementalTimingDrivenQP() : session(nullptr), infra(nullptr), design(nullptr),
-			 timer(nullptr), libc(nullptr), debugMode(false),
-			 enableRC( false ), alpha( 0 ),
-			 maxNumPaths( 5000 ),
-             legMode( LegalizationMethod::LEG_NEAREST_WHITESPACE ),
-			 roolbackOnMaxDisplacementViolation(true),
-			 minimumResistance(0.01) {};
-	
 	void initIncrementalTimingDrivenQP();
 	
 	void setSession(Rsyn::Session ptr);


### PR DESCRIPTION
During compilation of rsyn with warnings enabled, there are thousands of
warnings. This patch fixes all the warnings produced when -Wreorder is
passed to gcc (enabled by default with -Wall).

The fix moves the initialization of member variables from the constructors
to default member initializers (C++ 11), which make it easier to know the
default value, it's clearer to see which members might have not been
default-initialized, and in many cases allows the removal of the default
constructor, moving all the job to the compiler (less code == less bugs).